### PR TITLE
Refactor OSC transport hold logic

### DIFF
--- a/zoom/osc_server.py
+++ b/zoom/osc_server.py
@@ -338,10 +338,8 @@ def handle_snap_target_toggle(address, args):
         print(f"OSC VSE: error calling strips_tools._rebuild_snap_targets(): {e}")
 
 command_handler_map = {
-    "/star_hold_previous": transport_extra.transport_extra_receive,
-    "/end_hold_previous": transport_extra.transport_extra_receive,
-    "/star_hold_next": transport_extra.transport_extra_receive,
-    "/end_hold_next": transport_extra.transport_extra_receive,
+    "/hold_next": transport_extra.handle_transport_hold,
+    "/hold_previous": transport_extra.handle_transport_hold,
     "/toggle_play": transport_extra.handle_play_logic,
     "/shift": transport_extra.handle_shift_logic,
     "/Jog": transport_extra.handle_jog_logic,


### PR DESCRIPTION
Replaced the `transport_extra_receive` function with a new `handle_transport_hold` function in `transport_extra.py`.

The new handler uses a single set of addresses (`/hold_next`, `/hold_previous`) and a boolean argument to manage the hold state, simplifying the logic.

Updated the `command_handler_map` in `osc_server.py` to use the new handler and remove the obsolete addresses.

Removed the now-unused `transport_extra_receive` function.